### PR TITLE
ESAUDE-39: Updated DHIS2 API endpoints to target specific properties

### DIFF
--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/impl/DHISConnectorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/impl/DHISConnectorServiceImpl.java
@@ -80,7 +80,7 @@ public class DHISConnectorServiceImpl extends BaseOpenmrsService implements DHIS
 	
 	public static final String DHISCONNECTOR_MAPPING_FILE_SUFFIX = ".mapping.json";
 	
-	public static final String DHISCONNECTOR_ORGUNIT_RESOURCE = "/api/organisationUnits.json?paging=false";
+	public static final String DHISCONNECTOR_ORGUNIT_RESOURCE = "/api/organisationUnits.json?paging=false&fields=id,name";
 	
 	public static final String DATASETS_PATH = "/api/dataValueSets";
 	
@@ -718,8 +718,8 @@ public class DHISConnectorServiceImpl extends BaseOpenmrsService implements DHIS
 	private boolean matchingDHIS2APIBackUpStructure(File file) {
 		return StringUtils.equals(file.getName(), "api") || StringUtils.equals(file.getName(), "categoryCombos")
 		        || StringUtils.equals(file.getName(), "dataElements") || StringUtils.equals(file.getName(), "dataSets")
-		        || StringUtils.equals(file.getName(), "organisationUnits.json?paging=false")
-		        || StringUtils.equals(file.getName(), "dataSets.jsonpaging=false") || file.getName().endsWith(".json");
+		        || StringUtils.equals(file.getName(), "organisationUnits.json?paging=false&fields=id,name")
+		        || StringUtils.equals(file.getName(), "dataSets.json?paging=false&fields=id,name") || file.getName().endsWith(".json");
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/resource/DHISCategoryCombosResource.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/resource/DHISCategoryCombosResource.java
@@ -32,12 +32,14 @@ public class DHISCategoryCombosResource extends DataDelegatingCrudResource imple
 
 	public static final String CATEGORYCOMBOS_PATH = "/api/categoryCombos";
 
+	private static final String COC_FIELDS_PARAM = "?fields=id,name,categoryOptionCombos[id,name],categories[id,name]";
+
 	@Override
 	public DHISCategoryCombo getByUniqueId(String s) {
 		ObjectMapper mapper = new ObjectMapper();
 
 		String jsonResponse = Context.getService(DHISConnectorService.class)
-				.getDataFromDHISEndpoint(CATEGORYCOMBOS_PATH + "/" + s + DHISDataSetsResource.JSON_SUFFIX);
+				.getDataFromDHISEndpoint(CATEGORYCOMBOS_PATH + "/" + s + DHISDataSetsResource.JSON_SUFFIX + COC_FIELDS_PARAM);
 
 		DHISCategoryCombo ret = null;
 

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/resource/DHISDataElementsResource.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/resource/DHISDataElementsResource.java
@@ -32,12 +32,14 @@ public class DHISDataElementsResource extends DataDelegatingCrudResource impleme
 
 	public static final String DATAELEMENTS_PATH = "/api/dataElements";
 
+	private static final String CO_FIELDS_PARAM = "?fields=id,name,categoryCombo[id,name]";
+
 	@Override
 	public DHISDataElement getByUniqueId(String s) {
 		ObjectMapper mapper = new ObjectMapper();
 
 		String jsonResponse = Context.getService(DHISConnectorService.class)
-				.getDataFromDHISEndpoint(DATAELEMENTS_PATH + "/" + s + DHISDataSetsResource.JSON_SUFFIX);
+				.getDataFromDHISEndpoint(DATAELEMENTS_PATH + "/" + s + DHISDataSetsResource.JSON_SUFFIX + CO_FIELDS_PARAM);
 
 		DHISDataElement ret = null;
 

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/resource/DHISDataSetsResource.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/resource/DHISDataSetsResource.java
@@ -41,7 +41,11 @@ public class DHISDataSetsResource extends DataDelegatingCrudResource implements 
 
 	public static final String JSON_SUFFIX = ".json";
 
-	public static final String NO_PAGING_PARAM = "paging=false";
+	public static final String NO_PAGING_PARAM = "?paging=false";
+
+	private static final String NO_PAGING_IDENTIFIABLE_PARAM = "&fields=id,name";
+
+    private static final String DE_IDENTIFIABLE_PARAM = "?fields=*,dataElements[id,name]";
 
 	@Override
 	public DHISDataSet getByUniqueId(String s) {
@@ -49,7 +53,7 @@ public class DHISDataSetsResource extends DataDelegatingCrudResource implements 
 		ObjectMapper mapper = new ObjectMapper();
 
 		String jsonResponse = Context.getService(DHISConnectorService.class)
-				.getDataFromDHISEndpoint(DATASETS_PATH + "/" + s + JSON_SUFFIX);
+				.getDataFromDHISEndpoint(DATASETS_PATH + "/" + s + JSON_SUFFIX + DE_IDENTIFIABLE_PARAM);
 
 		DHISDataSet ret = null;
 
@@ -93,7 +97,7 @@ public class DHISDataSetsResource extends DataDelegatingCrudResource implements 
 		JsonNode node;
 
 		jsonResponse = Context.getService(DHISConnectorService.class)
-				.getDataFromDHISEndpoint(DATASETS_PATH + JSON_SUFFIX + NO_PAGING_PARAM);
+				.getDataFromDHISEndpoint(DATASETS_PATH + JSON_SUFFIX + NO_PAGING_PARAM + NO_PAGING_IDENTIFIABLE_PARAM);
 
 		try {
 			node = mapper.readTree(jsonResponse);


### PR DESCRIPTION
Targeting specific properties allows for consistency when querying dhis2 api enpoints over various versions of dhis. Newer version has changed the defualt set of properties that are returned.
